### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Deploy site `vercel`.
 
 See [how to contribute](https://contributte.org/contributing.html) to this package.
 
-This package is currently maintaining by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">


### PR DESCRIPTION
## Summary

This PR updates the README.md to properly follow the archive style template by fixing the Development section text.

## Changes

- Changed "This package is currently maintaining by these authors" to "This package was maintained by these authors" (past tense)

The repository was already using the archive style (Option C for website/site projects) with:
- Deprecation badge with `?deprecated=1` parameter
- Disclaimer section pointing to contributte/contributte-site
- Screenshot of the site
- All required badges and links

This change ensures consistency with the archive template standard.